### PR TITLE
feat(content): update INTRO_BIO_SHORT tagline to AI-Native Senior Full-Stack SWE

### DIFF
--- a/constants/SITE_CONTENT.ts
+++ b/constants/SITE_CONTENT.ts
@@ -28,13 +28,13 @@ export const SHOW_DR_MAPACHE = false
 
 
 export const INTRO_BIO_SHORT =
-  "Indie Game Dev · AI Context Engineer · I teach LLMs to think · Full-Stack SWE since 2005 · BS & MS in Bioinformatics at age 19 · Doctor of Physical Therapy" as const
+  "AI-Native Senior Full-Stack SWE · Design Engineer · Indie Game Dev · 20+ years of SWE since 2005 · BS & MS age 19 · Doctor of Physical Therapy" as const
 
 export const ABOUT_BIO_LONG: string[] = [
-  "I’m Dr. Derek Austin: an Indie Game Dev, AI Context Engineer, and senior full-stack SWE. I don’t just use AI; I teach LLMs how to think.",
+  "I\u2019m Dr. Derek Austin: an Indie Game Dev, AI Context Engineer, and senior full-stack SWE. I don\u2019t just use AI; I teach LLMs how to think.",
   "Earning a BS and MS in Bioinformatics by age 19 taught me to isolate clear signals in massive datasets. Today, I apply that rigorous, first-principles logic to deconstructing complex codebases.",
-  "Frustrated by standard “gaslighting” AI, I spent 2,000+ hours and 20M+ tokens architecting a solution. I engineer the deep context, agentic workflows, and cognitive frameworks that force frontier models into genuine, high-level code understanding.",
-  "This cognitive architecture drives 10× development velocity natively across disparate tech stacks: Next.js, TypeScript, and Postgres for cloud-native SaaS, and Godot 4 / C# for indie games.",
+  "Frustrated by standard \u201cgaslighting\u201d AI, I spent 2,000+ hours and 20M+ tokens architecting a solution. I engineer the deep context, agentic workflows, and cognitive frameworks that force frontier models into genuine, high-level code understanding.",
+  "This cognitive architecture drives 10\u00d7 development velocity natively across disparate tech stacks: Next.js, TypeScript, and Postgres for cloud-native SaaS, and Godot 4 / C# for indie games.",
   "I operate from Puebla, Mexico, alongside my amazing wife, Abby, and our two cats, Louie and Yuma. I write about my exact systems, failures, and victories on Medium. Thanks for reading!",
 ] as const
 
@@ -48,8 +48,8 @@ export type AiConsultancyPitch = {
 
 export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
   header: "Async AI Audit",
-  body: "Standard LLMs generate slop because their context is rotten. I engineer Human-AI Cognitive Systems that force frontier models to reason, not just predict text. Whether you need a brutal teardown of your current architecture or bespoke context engineering (a “constitution”) for your LLM chat workflow or autonomous agents, I provide the elite context, persona, and systems engineering to fix it.",
-  ctaButtonText: "Book a 20-Min Async AI Audit — $500 USD",
+  body: "Standard LLMs generate slop because their context is rotten. I engineer Human-AI Cognitive Systems that force frontier models to reason, not just predict text. Whether you need a brutal teardown of your current architecture or bespoke context engineering (a \u201cconstitution\u201d) for your LLM chat workflow or autonomous agents, I provide the elite context, persona, and systems engineering to fix it.",
+  ctaButtonText: "Book a 20-Min Async AI Audit \u2014 $500 USD",
   subtext:
     "For a serious head start to your startup or indie game development using LLMs: $5,000 USD anchor point for a Custom AI Constitution / Master GDD Template.",
   emailSubject: "AI Cognitive Architecture Inquiry",
@@ -57,7 +57,7 @@ export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
 
 export const CONTACT_BULLETS: string[] = [
   "I build, architect, and scale robust software systems and engineer elite Human-AI cognitive frameworks.",
-  "While I am highly selective about full-time roles—prioritizing elite, AI-first engineering teams—I also consult on high-leverage technical challenges.",
+  "While I am highly selective about full-time roles\u2014prioritizing elite, AI-first engineering teams\u2014I also consult on high-leverage technical challenges.",
   "Reach out for a $500 Async AI Audit or a $5,000 Master GDD Template.",
 ] as const
 export const CONTACT_CTA = "Request Async Audit" as const
@@ -69,24 +69,24 @@ export type WorkExperience = {
 
 export const ARCHITECT_EVOLUTION: WorkExperience[] = [
   {
-    duration: "2024–Present",
+    duration: "2024\u2013Present",
     company:
       "AI Context Engineer & Indie Game Dev | Godot C#, GDScript, 20M+ Tokens",
   },
   {
-    duration: "2020–2024",
+    duration: "2020\u20132024",
     company: "Senior Full-Stack SWE | React, Next.js, TypeScript, Tailwind CSS",
   },
   {
-    duration: "2019–2020",
+    duration: "2019\u20132020",
     company: "Senior React SWE | React, JavaScript, CSS",
   },
   {
-    duration: "2009–2019",
+    duration: "2009\u20132019",
     company: "Full-Stack Web Developer | HTML, CSS, JavaScript",
   },
   {
-    duration: "2005–2009",
+    duration: "2005\u20132009",
     company: "Software Engineer | C++, PHP, HTML, CSS, Ruby on Rails, SQL",
   },
 ] as const
@@ -126,7 +126,7 @@ export type LegalDisclaimer = {
 
 export const LEGAL_DISCLAIMER: LegalDisclaimer = {
   aiDisclosure: [
-    "Hello, fellow human! I'm Dr. Derek Austin. Thanks for visiting! 👋",
+    "Hello, fellow human! I\u2019m Dr. Derek Austin. Thanks for visiting! \ud83d\udc4b",
     "I use LLMs to augment 100% of my software engineering, code architecture, data visualization, and proofreading.",
     "On my Medium blog (Career Programming and According to Context), I use LLMs for data visualization and proofreading ONLY.",
     "I do not use AI-generated images, video, nor text on Career Programming or According to Context.",
@@ -136,10 +136,10 @@ export const LEGAL_DISCLAIMER: LegalDisclaimer = {
     "This content is for entertainment and educational purposes ONLY. It does NOT constitute career, financial, legal, health, psychological, or any other type of professional advice.",
     "I have included ALL content relating to the conduct, views, activities, and/or aspects of ALL persons or characters for ENTERTAINMENT PURPOSES ONLY.",
     "This website does NOT represent an assertion of fact on those matters or any matters related to ANY persons, living or dead.",
-    "ALL included data / facts should be considered illustrative, NOT definitive; thus, the website’s veracity should not be relied on under ANY circumstances beyond ENTERTAINMENT.",
-    "THIS WEBSITE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED!",
+    "ALL included data / facts should be considered illustrative, NOT definitive; thus, the website\u2019s veracity should not be relied on under ANY circumstances beyond ENTERTAINMENT.",
+    "THIS WEBSITE IS PROVIDED \u201cAS IS\u201d, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED!",
     "IN NO EVENT SHALL I BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM THIS WEBSITE.",
-    "Side effects may include systems thinking. BROWSE AT YOUR OWN RISK! 😉🫡🦝",
+    "Side effects may include systems thinking. BROWSE AT YOUR OWN RISK! \ud83d\ude09\ud83e\udee1\ud83e\udd9d",
   ],
 } as const
 
@@ -186,7 +186,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Venture Capitalist",
     image: johnImage,
     comment:
-      "It is my pleasure to recommend Derek. He and I have worked together since he started at [JOB], and I have always been impressed with his organization, communication, work product, and work ethic. As a co-founder of a startup, I have leaned on Derek’s strengths as an Engineering Manager, and I would like to highlight specific areas where Derek excels.\n\n1 – Derek possesses strong organizational skills. Not only is Derek adept at managing his own engineering tasks, but he frequently supports other [JOB] developers as they breakdown problems. His ability to organize how to tackle a problem has helped improve the output of the entire engineering team while allowing junior engineers to gain confidence. He thinks systematically, creating processes that ensure smooth workflows, and he has built a [JOB] engineering system that will continue to live on.\n\n2 – Derek’s strong communication skills are tied closely to his organized approach. He provides comprehensive information backed with research to help communicate points allowing the team to make good decisions more quickly. For example, when asked to present his thoughts on how the engineering team should grow, Derek laid out a clear, concise (yet comprehensive) presentation describing options and weighing pros / cons for each potential scenario. This presentation sped the time to decision which is critical in an early-stage startup. Derek demonstrates a strong ability to think through a problem or question deeply then communicate those points to others.\n\n3 – Derek’s ability to think through problems deeply and then deliver high-quality work product makes him an asset to engineering teams. He is adept at writing tickets, planning work, and having a vision for how features should be built for continued improvement of the product. Derek researches technologies and architectures to ensure [JOB] doesn’t make missteps as we continue to improve on the product which will pay future dividends for our team. Derek also created a thoughtful, structured approach to career development for our junior software engineers. His system of mentoring based on Accountability, Accuracy, and Acceleration is something that has helped me better understand the performance and growth of our engineering hires.\n\n4 – Derek can deliver high-quality work product because of his tremendous work ethic, and his commitment to accountability as a software engineer and manager. If he says that he will take on a piece of work, he takes it on and delivers a high-quality result. We asked Derek to step into the Engineer Manager role, and he grew into the role. He holds himself and his team accountable for product deliverables which means that [JOB] can deliver a high-quality tech product on a timely basis. As a leader, I can count on Derek to fully own the code development process, and I am impressed with his ability to put work down to jump on high-impact bugs solving them quickly with little interruption to our users.",
+      "It is my pleasure to recommend Derek. He and I have worked together since he started at [JOB], and I have always been impressed with his organization, communication, work product, and work ethic. As a co-founder of a startup, I have leaned on Derek\u2019s strengths as an Engineering Manager, and I would like to highlight specific areas where Derek excels.\n\n1 \u2013 Derek possesses strong organizational skills. Not only is Derek adept at managing his own engineering tasks, but he frequently supports other [JOB] developers as they breakdown problems. His ability to organize how to tackle a problem has helped improve the output of the entire engineering team while allowing junior engineers to gain confidence. He thinks systematically, creating processes that ensure smooth workflows, and he has built a [JOB] engineering system that will continue to live on.\n\n2 \u2013 Derek\u2019s strong communication skills are tied closely to his organized approach. He provides comprehensive information backed with research to help communicate points allowing the team to make good decisions more quickly. For example, when asked to present his thoughts on how the engineering team should grow, Derek laid out a clear, concise (yet comprehensive) presentation describing options and weighing pros / cons for each potential scenario. This presentation sped the time to decision which is critical in an early-stage startup. Derek demonstrates a strong ability to think through a problem or question deeply then communicate those points to others.\n\n3 \u2013 Derek\u2019s ability to think through problems deeply and then deliver high-quality work product makes him an asset to engineering teams. He is adept at writing tickets, planning work, and having a vision for how features should be built for continued improvement of the product. Derek researches technologies and architectures to ensure [JOB] doesn\u2019t make missteps as we continue to improve on the product which will pay future dividends for our team. Derek also created a thoughtful, structured approach to career development for our junior software engineers. His system of mentoring based on Accountability, Accuracy, and Acceleration is something that has helped me better understand the performance and growth of our engineering hires.\n\n4 \u2013 Derek can deliver high-quality work product because of his tremendous work ethic, and his commitment to accountability as a software engineer and manager. If he says that he will take on a piece of work, he takes it on and delivers a high-quality result. We asked Derek to step into the Engineer Manager role, and he grew into the role. He holds himself and his team accountable for product deliverables which means that [JOB] can deliver a high-quality tech product on a timely basis. As a leader, I can count on Derek to fully own the code development process, and I am impressed with his ability to put work down to jump on high-impact bugs solving them quickly with little interruption to our users.",
   },
   {
     id: 2,
@@ -194,7 +194,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Senior Full-Stack Software Engineer",
     image: yosevuImage,
     comment:
-      "I had the privilege of working with Derek for a year at [JOB]. He is one of the most dedicated and talented people I’ve worked with. He cares deeply about the projects he is a part of, as well as the success of the team and organization as whole. Derek’s commitment is reflected in his holistic approach to management and software development.\n\nHe instilled a high level of ownership and accountability at [JOB], modeling high standards for those around him. His clear and direct verbal and written communication made it easier to know what was expected and helped to keep the team aligned and focused.\n\nOne of the things that sets Derek apart is his expertise as both a technical manager and a highly productive engineer with a strong product sense. He is thoughtful with software architecture, the development process, and staying up to date with technologies, patterns, and best practices with React, Next.js, and TypeScript. This combination ensured efficiency and quality throughout our work together at [JOB], delivering our projects successfully and keeping our team performing at its best.\n\nIn addition to his technical skills, Derek is also a valuable mentor. He is always ready to share his extensive knowledge and experience in software and provide constructive feedback. He created opportunities for growth that helped level up the skills of myself and other team members at [JOB], encouraging a culture of continuous improvement. Derek was an incredible asset at [JOB] and I would jump at the opportunity to work with him again in the future!",
+      "I had the privilege of working with Derek for a year at [JOB]. He is one of the most dedicated and talented people I\u2019ve worked with. He cares deeply about the projects he is a part of, as well as the success of the team and organization as whole. Derek\u2019s commitment is reflected in his holistic approach to management and software development.\n\nHe instilled a high level of ownership and accountability at [JOB], modeling high standards for those around him. His clear and direct verbal and written communication made it easier to know what was expected and helped to keep the team aligned and focused.\n\nOne of the things that sets Derek apart is his expertise as both a technical manager and a highly productive engineer with a strong product sense. He is thoughtful with software architecture, the development process, and staying up to date with technologies, patterns, and best practices with React, Next.js, and TypeScript. This combination ensured efficiency and quality throughout our work together at [JOB], delivering our projects successfully and keeping our team performing at its best.\n\nIn addition to his technical skills, Derek is also a valuable mentor. He is always ready to share his extensive knowledge and experience in software and provide constructive feedback. He created opportunities for growth that helped level up the skills of myself and other team members at [JOB], encouraging a culture of continuous improvement. Derek was an incredible asset at [JOB] and I would jump at the opportunity to work with him again in the future!",
   },
   {
     id: 3,
@@ -202,7 +202,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "UI/UX Designer",
     image: toriImage,
     comment:
-      "Derek is an extremely talented engineer and an advocate not just for product users, but also for the people building the product. During our time at [JOB], Derek and I worked closely on a small team to build a flexible design system to power our new cross-functional web app.\n\nDerek consistently advocated for doing the upfront work to keep our team in a good position down the line. Additionally, as we started building the experience, Derek always advocated for the user, going beyond the basic flows to support fleshing out states, transitions, and moments of joy — often adding improvements and suggestions along the way. He has a keen attention to detail and truly brings a designer’s vision to life accurately and accessibly.\n\nDerek has a deep wealth of knowledge both in engineering and in life, and he has a knack for breaking down complex terms and concepts so our team could explore new workflows, improve skills, and find better ways of working. He led an internal recurring meeting on ways to practice positive psychology and is quick to practice what he teaches.\n\nHe consistently gives positive recognition to his team and was a big advocate for creating connection in a remote space — I’ll especially miss his movie recommendations each week! To sum it all up, Derek would be an ideal candidate for a company looking to get things done the right way.",
+      "Derek is an extremely talented engineer and an advocate not just for product users, but also for the people building the product. During our time at [JOB], Derek and I worked closely on a small team to build a flexible design system to power our new cross-functional web app.\n\nDerek consistently advocated for doing the upfront work to keep our team in a good position down the line. Additionally, as we started building the experience, Derek always advocated for the user, going beyond the basic flows to support fleshing out states, transitions, and moments of joy \u2014 often adding improvements and suggestions along the way. He has a keen attention to detail and truly brings a designer\u2019s vision to life accurately and accessibly.\n\nDerek has a deep wealth of knowledge both in engineering and in life, and he has a knack for breaking down complex terms and concepts so our team could explore new workflows, improve skills, and find better ways of working. He led an internal recurring meeting on ways to practice positive psychology and is quick to practice what he teaches.\n\nHe consistently gives positive recognition to his team and was a big advocate for creating connection in a remote space \u2014 I\u2019ll especially miss his movie recommendations each week! To sum it all up, Derek would be an ideal candidate for a company looking to get things done the right way.",
   },
   {
     id: 6,
@@ -210,7 +210,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Geopolitical Consultant",
     image: stevenImage,
     comment:
-      "Professional: Derek designed, built, and copy wrote two of my websites, including my new one. I had originally suggested a WordPress.com blog, which Derek designed and built out to my specifications. However, we agreed that my blog could reach a larger audience at Medium, so Derek redesigned and rebuilt the WordPress website. He came up with an impressive, original web design while significantly improving the website’s performance and mobile design.\n\nThe WordPress site took over 12 seconds to load, but the new site loads in under 3 seconds. He even added a dark mode, which was a great touch. Derek remained enthusiastic about the project throughout, and went the extra mile to make sure the site was written with high-quality code and would rank well for SEO. His exceptional writing and ability to organize information really put my site over the top. I’ve already referred Derek to a colleague looking for a new website because I absolutely trust his problem solving and communication skills. I would genuinely recommend him to anyone looking for a web developer who’s also a great communicator.\n\nPersonal: Derek and I have been friends since freshman year of high school, when he was 11. Even then, one of his biggest strengths was his ability to explain complex topics in simple terms. He’s not didactic or trying to teach, he’s just a natural educator. He’s also adventurous, creative, and always meticulously working on something cool and new. Ask him about his travels, his charity project, gaming, programming, web development, genetics, physical therapy, etc. He’s a fun dude who isn’t afraid to seize the day.",
+      "Professional: Derek designed, built, and copy wrote two of my websites, including my new one. I had originally suggested a WordPress.com blog, which Derek designed and built out to my specifications. However, we agreed that my blog could reach a larger audience at Medium, so Derek redesigned and rebuilt the WordPress website. He came up with an impressive, original web design while significantly improving the website\u2019s performance and mobile design.\n\nThe WordPress site took over 12 seconds to load, but the new site loads in under 3 seconds. He even added a dark mode, which was a great touch. Derek remained enthusiastic about the project throughout, and went the extra mile to make sure the site was written with high-quality code and would rank well for SEO. His exceptional writing and ability to organize information really put my site over the top. I\u2019ve already referred Derek to a colleague looking for a new website because I absolutely trust his problem solving and communication skills. I would genuinely recommend him to anyone looking for a web developer who\u2019s also a great communicator.\n\nPersonal: Derek and I have been friends since freshman year of high school, when he was 11. Even then, one of his biggest strengths was his ability to explain complex topics in simple terms. He\u2019s not didactic or trying to teach, he\u2019s just a natural educator. He\u2019s also adventurous, creative, and always meticulously working on something cool and new. Ask him about his travels, his charity project, gaming, programming, web development, genetics, physical therapy, etc. He\u2019s a fun dude who isn\u2019t afraid to seize the day.",
   },
   {
     id: 4,
@@ -218,7 +218,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Full-Stack Developer",
     image: pranjalImage,
     comment:
-      "Dr. Derek Austin is an exceptional engineering manager who fosters a positive and growth-oriented environment for his team. I had the pleasure of working under his leadership for almost a year as a full-stack developer.\n\nDr. Austin’s guidance was instrumental in helping me develop my problem-solving skills. While working on the [JOB] cross-platform application, his insights always helped us overcome critical technical hurdles and ultimately deliver the features on time.\n\nDr. Austin is a highly skilled communicator who excels at delegating tasks and motivating his team members. I highly recommend Dr. Austin to anyone seeking a talented and inspiring engineering manager.",
+      "Dr. Derek Austin is an exceptional engineering manager who fosters a positive and growth-oriented environment for his team. I had the pleasure of working under his leadership for almost a year as a full-stack developer.\n\nDr. Austin\u2019s guidance was instrumental in helping me develop my problem-solving skills. While working on the [JOB] cross-platform application, his insights always helped us overcome critical technical hurdles and ultimately deliver the features on time.\n\nDr. Austin is a highly skilled communicator who excels at delegating tasks and motivating his team members. I highly recommend Dr. Austin to anyone seeking a talented and inspiring engineering manager.",
   },
   {
     id: 5,
@@ -226,7 +226,7 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Software Engineer",
     image: danImage,
     comment:
-      "As a graduate of Nucamp Web Development Bootcamp who was in the process of finishing my second Bachelor’s, I knew I was right on the cusp of getting a great position as a front-end engineer. I asked for resume feedback in the Nucamp Slack community, and Dr. Derek Austin volunteered to provide me detailed notes on my resume and portfolio.\n\nHis helpful attitude and enthusiasm impressed me, as I hadn’t been one of his students, so his mentoring really went above & beyond. His knowledge of both software engineering and personal marketing made an impact right away. After a few weeks of collaboration, I could better communicate my personal brand, and suddenly I was having much better results from my job hunt.\n\nNow that I’m working as a front end developer, I’ve had the chance to “pay it forward” and help other engineers with their own job hunts. I’d recommend Dr. Derek Austin for anyone needing a front-end developer, mentor, technical writer, or entrepreneur.",
+      "As a graduate of Nucamp Web Development Bootcamp who was in the process of finishing my second Bachelor\u2019s, I knew I was right on the cusp of getting a great position as a front-end engineer. I asked for resume feedback in the Nucamp Slack community, and Dr. Derek Austin volunteered to provide me detailed notes on my resume and portfolio.\n\nHis helpful attitude and enthusiasm impressed me, as I hadn\u2019t been one of his students, so his mentoring really went above & beyond. His knowledge of both software engineering and personal marketing made an impact right away. After a few weeks of collaboration, I could better communicate my personal brand, and suddenly I was having much better results from my job hunt.\n\nNow that I\u2019m working as a front end developer, I\u2019ve had the chance to \u201cpay it forward\u201d and help other engineers with their own job hunts. I\u2019d recommend Dr. Derek Austin for anyone needing a front-end developer, mentor, technical writer, or entrepreneur.",
   },
   {
     id: 7,
@@ -234,6 +234,6 @@ export const TESTIMONIALS: Testimonial[] = [
     title: "Author and Content Creator",
     image: anangshaImage,
     comment:
-      "I came across Dr. Derek’s articles on Medium and was always fascinated by how detailed and well-presented they were. He has fantastic writing skills that make it hard for a reader to stop reading once they started.\n\nI attended his talk at Momentum 2021, and even though I’m not an SEO geek, I found his talk incredibly valuable. It gave me a lot of things to think about when I write, and some important information about how to structure a headline that gives you clicks.\n\nDr. Derek is also a fantastic editor. He edited an article that took me the longest time to write, and with his inputs, it became even better. If you’re ever looking for a technical writer, an editor, or an SEO specialist, I can’t recommend Dr. Derek enough.",
+      "I came across Dr. Derek\u2019s articles on Medium and was always fascinated by how detailed and well-presented they were. He has fantastic writing skills that make it hard for a reader to stop reading once they started.\n\nI attended his talk at Momentum 2021, and even though I\u2019m not an SEO geek, I found his talk incredibly valuable. It gave me a lot of things to think about when I write, and some important information about how to structure a headline that gives you clicks.\n\nDr. Derek is also a fantastic editor. He edited an article that took me the longest time to write, and with his inputs, it became even better. If you\u2019re ever looking for a technical writer, an editor, or an SEO specialist, I can\u2019t recommend Dr. Derek enough.",
   },
 ]


### PR DESCRIPTION
## Summary
Updates `INTRO_BIO_SHORT` in `constants/SITE_CONTENT.ts` to align with the new Medium profile tagline.

### Changed File
- `constants/SITE_CONTENT.ts`: `INTRO_BIO_SHORT` updated from `"Indie Game Dev · AI Context Engineer · I teach LLMs to think · Full-Stack SWE since 2005 · BS & MS in Bioinformatics at age 19 · Doctor of Physical Therapy"` to `"AI-Native Senior Full-Stack SWE · Design Engineer · Indie Game Dev · 20+ years of SWE since 2005 · BS & MS age 19 · Doctor of Physical Therapy"`

Closes #14

---

### 5RUN QA Checklist
- [ ] Verify the typewriter effect on the Intro section renders the new tagline correctly
- [ ] Confirm no layout breaks on mobile or desktop from the slightly different string length
- [ ] Check that no other component references the old tagline text directly