### PR TITLE
feat(about): swap second photo from DrDerekAustin.png to DerekAustin2.jpg

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react"
 import { ABOUT_BIO_LONG, SHOW_DR_MAPACHE } from "@/constants/SITE_CONTENT"
 import DerekAustin from "@/images/DerekAustin.png"
 import DerekAustin2 from "@/images/DerekAustin2.jpg"
+import DerekAustin3 from "@/images/DerekAustin3.jpg"
 import Image from "next/image"
 import SectionHeading from "@/components/ui/SectionHeading"
 
@@ -27,10 +28,10 @@ export default function AboutSection() {
     }
   }, [])
 
-  const photos = [DerekAustin, DerekAustin2]
+  const photos = [DerekAustin, DerekAustin2, DerekAustin3]
 
-  const currentPhoto = photos[flipCount % 2]
-  const nextPhoto = photos[(flipCount + 1) % 2]
+  const currentPhoto = photos[flipCount % 3]
+  const nextPhoto = photos[(flipCount + 1) % 3]
 
   const frontSrc = flipCount % 2 === 0 ? currentPhoto : nextPhoto
   const backSrc = flipCount % 2 === 1 ? currentPhoto : nextPhoto

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react"
 import { ABOUT_BIO_LONG, SHOW_DR_MAPACHE } from "@/constants/SITE_CONTENT"
 import DerekAustin from "@/images/DerekAustin.png"
-import DrDerekAustin from "@/images/DrDerekAustin.png"
+import DerekAustin2 from "@/images/DerekAustin2.jpg"
 import Image from "next/image"
 import SectionHeading from "@/components/ui/SectionHeading"
 
@@ -27,7 +27,7 @@ export default function AboutSection() {
     }
   }, [])
 
-  const photos = [DerekAustin, DrDerekAustin]
+  const photos = [DerekAustin, DerekAustin2]
 
   const currentPhoto = photos[flipCount % 2]
   const nextPhoto = photos[(flipCount + 1) % 2]
@@ -122,7 +122,7 @@ export default function AboutSection() {
                 <div className="rounded-2xl border border-[#F38B57]/20 bg-black/50 p-4 shadow-xl backdrop-blur-md">
                   <p className="animate-pulse text-lg leading-tight font-bold text-white drop-shadow-md lg:text-xl">
                     But enough talk. Scroll down to play the WebGL game I built to
-                    prove my stack. 👇🎮🦝
+                    prove my stack. \ud83d\udc47\ud83c\udfae\ud83e\udd9d
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Summary
Expands the About section photo flip from 2 images to a 3-image cycle: `DerekAustin.png`, `DerekAustin2.jpg`, and `DerekAustin3.jpg`. Replaces the deleted `DrDerekAustin.png` import.

### Changed File
- `components/AboutSection.tsx`:
  - Removed: `import DrDerekAustin from "@/images/DrDerekAustin.png"`
  - Added: `import DerekAustin2 from "@/images/DerekAustin2.jpg"` and `import DerekAustin3 from "@/images/DerekAustin3.jpg"`
  - `photos` array: `[DerekAustin, DrDerekAustin]` -> `[DerekAustin, DerekAustin2, DerekAustin3]`
  - Flip index: modulo 2 -> modulo 3 for `currentPhoto`/`nextPhoto` selection

Closes #12

---

### 5RUN QA Checklist
- [ ] Verify the About section photo flip cycles through all 3 distinct images
- [ ] Confirm each image renders at full quality (not blurry) on both front and back faces
- [ ] Test hover flip and click flip both cycle through all 3 photos
- [ ] Verify no broken image references on mobile or desktop
- [ ] Check that the 3rd flip returns to the 1st image (correct modulo 3 wrap)