### PR TITLE
fix: update SITE_CONTENT copy (closes #26)

### DIFF
--- a/constants/SITE_CONTENT.ts
+++ b/constants/SITE_CONTENT.ts
@@ -31,7 +31,7 @@ export const INTRO_BIO_SHORT =
   "AI-Native Senior Full-Stack SWE · Design Engineer · Indie Game Dev · 20+ years of SWE since 2004 · BS & MS age 19 · Doctor of Physical Therapy" as const
 
 export const ABOUT_BIO_LONG: string[] = [
-  "I'm Dr. Derek Austin: an AI-Native Senior Full-Stack SWE, Fractional Architect, and Design Engineer. I specialize in architecting and building full-stack TypeScript apps that scale and world-class UI/UX that “feels” right.",
+  "I’m Dr. Derek Austin: an AI-Native Senior Full-Stack SWE, Fractional Architect, and Design Engineer. I specialize in architecting and building full-stack TypeScript apps that scale and world-class UI/UX that “feels” right.",
   "I leverage frontier LLMs like Gemini Deep Think and Claude Opus every day, but I explicitly reject the technical debt of “vibe coding.” When using agentic and other AI-assisted SWE tools, I still take full ownership of the codebase and accountability for results.",
   "Using my strict 5-Step Forge (Plan, Build, Test, Reflect) and 35 “Anti-Slop” pillars, I build with deterministic state machines (XState) and scrub AI slop from my codebases.",
   "This methodology drives my 10× development velocity across disparate stacks: Next.js, TypeScript, Node.js, and Postgres for cloud-native SaaS; React Native + Expo for cross-platform mobile apps; and Godot 4 + C# for indie games.",

--- a/constants/SITE_CONTENT.ts
+++ b/constants/SITE_CONTENT.ts
@@ -31,11 +31,11 @@ export const INTRO_BIO_SHORT =
   "AI-Native Senior Full-Stack SWE · Design Engineer · Indie Game Dev · 20+ years of SWE since 2004 · BS & MS age 19 · Doctor of Physical Therapy" as const
 
 export const ABOUT_BIO_LONG: string[] = [
-  "I’m Dr. Derek Austin: an AI-Native Senior Full-Stack SWE, Fractional Architect, and Design Engineer. I explicitly reject the technical debt of “vibe coding.”",
-  "Earning a BS and MS by age 19 taught me to isolate clear signals in massive datasets. Today, I apply that rigorous, first-principles logic to engineering deterministic software architectures.",
-  "By exchanging 20M+ tokens with frontier LLMs using my strict 5-Step Forge process and 35 “Anti-Slop” pillars, I enforce deterministic state machines (XState) and scrub AI-generated slop from my codebases.",
-  "This methodology drives 10× development velocity natively across disparate tech stacks: Next.js, TypeScript, Node.js, and Postgres for cloud-native SaaS, and Godot 4 / C# for indie games.",
-  "I operate as a Sovereign Operator from Puebla, Mexico, alongside my amazing wife, Abby, and our two cats, Louie and Yuma. I write about my exact systems, failures, and victories for my 21,000+ followers on Medium. Thanks for reading!",
+  "I'm Dr. Derek Austin: an AI-Native Senior Full-Stack SWE, Fractional Architect, and Design Engineer. I specialize in architecting and building full-stack TypeScript apps that scale and world-class UI/UX that “feels” right.",
+  "I leverage frontier LLMs like Gemini Deep Think and Claude Opus every day, but I explicitly reject the technical debt of “vibe coding.” When using agentic and other AI-assisted SWE tools, I still take full ownership of the codebase and accountability for results.",
+  "Using my strict 5-Step Forge (Plan, Build, Test, Reflect) and 35 “Anti-Slop” pillars, I build with deterministic state machines (XState) and scrub AI slop from my codebases.",
+  "This methodology drives my 10× development velocity across disparate stacks: Next.js, TypeScript, Node.js, and Postgres for cloud-native SaaS; React Native + Expo for cross-platform mobile apps; and Godot 4 + C# for indie games.",
+  "I’m a US citizen and operate as an independent US 1099 contractor as a digital nomad. Currently I’m based in Puebla, Mexico, where I live with my wife, Abby, and our two cats. Contact me for fractional architecture and engineering if results, accountability, and UI/UX matter to you!",
 ] as const
 
 export type AiConsultancyPitch = {
@@ -48,7 +48,7 @@ export type AiConsultancyPitch = {
 
 export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
   header: "Fractional Architecture & Engineering",
-  body: "Startups are drowning in fragile, AI-generated prototypes that cannot scale. I help founders and VC-backed teams build deterministic, financial-grade platforms (Next.js, Node.js, Postgres) at 10x velocity. Using my strict 5-Step Forge process and “Anti-Slop” pillars, I deploy frontier LLMs to execute complex architectures without accumulating technical debt. I partner with teams as a Fractional Architect or Design Engineer to ship robust software that feels “right” for users.",
+  body: "Startups are drowning in fragile, AI-generated prototypes that cannot scale. I help founders and VC-backed teams build deterministic apps in regulated industries (like HealthTech) at 10x velocity. I hate bugs, I love results, and I know when to move fast and when to pay down tech debt. I partner with teams as a Fractional Architect (part-time) or Design Engineer (full-time) to ship robust, world-class software that feels “right” for users.",
   ctaButtonText: "Inquire About Availability",
   subtext:
     "Available for remote, async US 1099 or Global B2B contract roles. I operate primarily on high-leverage fractional retainers (10–20 hours/week) or full-time design engineering contracts.",
@@ -56,9 +56,10 @@ export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
 } as const
 
 export const CONTACT_BULLETS: string[] = [
-  "I architect, build, and scale deterministic software systems using elite, AI-augmented engineering workflows.",
-  "I partner with founders and early-stage startups on a fractional or full-time contract basis (US 1099 / Global B2B) to deliver 10x velocity without the technical debt of “vibe coding.”",
-  "Reach out to discuss how my Spec-Driven TDD and Anti-Slop methodologies can accelerate your engineering pipeline.",
+  "I architect, build, and scale deterministic software systems using elite, AI-augmented engineering approaches including agentic SWE workflows.",
+  "I’ve built my career around taking broken MVPs—whether delivered by underperforming agencies or AI—and turning them into real apps.",
+  "Currently, I partner with founders and early-stage startups on a fractional or full-time contract basis (US 1099 / Global B2B) to deliver 10x velocity without the technical debt of “vibe coding.”",
+  "Reach out to discuss how my 5-Step Forge (Plan, Build, Test, Reflect), Anti-Slop pillars, and commitment to using state machines for deterministic state management can accelerate your engineering pipeline.",
 ] as const
 export const CONTACT_CTA = "Discuss Contract Engagement" as const
 


### PR DESCRIPTION
## Summary

Applies all 3 verbatim copy diffs from issue #26 to `constants/SITE_CONTENT.ts`.

closes #26

---

## Files Changed

| File | Change |
|---|---|
| `constants/SITE_CONTENT.ts` | Updated `ABOUT_BIO_LONG`, `AI_CONSULTANCY_PITCH`, `CONTACT_BULLETS` |

---

## Diff 1: `ABOUT_BIO_LONG` (5 strings replaced)
- Rebrands around full-stack TypeScript apps, world-class UI/UX
- Adds LLM transparency (Gemini Deep Think, Claude Opus) with anti-vibe-coding stance
- Updates 5-Step Forge description to `(Plan, Build, Test, Reflect)`
- Adds React Native + Expo to tech stacks; changes `Godot 4 / C#` to `Godot 4 + C#`
- Repositions as US citizen / US 1099 contractor / digital nomad

## Diff 2: `AI_CONSULTANCY_PITCH` (body only)
- Targets regulated industries (HealthTech) instead of "financial-grade platforms"
- Adds personality: "I hate bugs, I love results"
- Clarifies Fractional Architect (part-time) vs Design Engineer (full-time)
- Adds "world-class" qualifier to shipped software

## Diff 3: `CONTACT_BULLETS` (3 → 4 bullets)
- Bullet 1: "workflows" → "approaches including agentic SWE workflows"
- Bullet 2 (NEW): Broken MVP turnaround positioning with em dash `—`
- Bullet 3: Prefixed with "Currently,"
- Bullet 4: "Spec-Driven TDD and Anti-Slop methodologies" → "5-Step Forge (Plan, Build, Test, Reflect), Anti-Slop pillars, and commitment to using state machines"

---

## 5RUN QA Checklist
- [ ] `ABOUT_BIO_LONG` renders 5 paragraphs in About section
- [ ] `AI_CONSULTANCY_PITCH` body shows "regulated industries (like HealthTech)"
- [ ] `CONTACT_BULLETS` shows 4 bullets (new MVP bullet with em dash)
- [ ] Curly quotes and curly apostrophes render correctly in all updated sections
- [ ] No regressions in other sections (testimonials, legal, social proof)