### PR TITLE
fix: contact, consultancy, about section updates (closes #28, #29, #30)

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -38,7 +38,7 @@ export default function AboutSection() {
 
   return (
     <div className="h-full w-full py-10 md:py-16">
-      <div className="mx-auto w-4/5 md:w-[90%] lg:w-3/4">
+      <div className="mx-auto w-4/5 md:w-[90%] lg:w-[90%]">
         <div className="-translate-x-12 py-2 text-white opacity-0 drop-shadow-md transition-all duration-700 ease-spring-soft md:relative md:py-8 lg:pt-14 lg:pb-10 [.active_&]:translate-x-0 [.active_&]:opacity-100">
           <SectionHeading>
             <h2 className="text-5xl min-[375px]:text-6xl font-semibold md:text-8xl lg:text-9xl">
@@ -110,9 +110,9 @@ export default function AboutSection() {
               </div>
             </div>
           </div>
-          <div className="relative mt-8 translate-y-12 rounded-tl-3xl border border-white/20 bg-black/40 px-6 py-5 opacity-0 backdrop-blur-xl transition-all delay-300 duration-700 ease-spring-soft md:absolute md:right-0 md:-bottom-8 md:left-auto md:w-[55%] lg:right-36 lg:bottom-12 lg:left-auto lg:w-1/2 lg:px-10 lg:py-7 [.active_&]:translate-y-0 [.active_&]:opacity-100">
+          <div className="relative mt-8 translate-y-12 rounded-tl-3xl border border-white/20 bg-black/40 px-6 py-5 opacity-0 backdrop-blur-xl transition-all delay-300 duration-700 ease-spring-soft md:absolute md:right-0 md:-bottom-8 md:left-auto md:w-[65%] lg:right-36 lg:bottom-12 lg:left-auto lg:w-[60%] lg:px-10 lg:py-7 [.active_&]:translate-y-0 [.active_&]:opacity-100">
             <div className="flex flex-col gap-4 lg:gap-6">
-              <div className="pr-2 text-lg leading-7 text-white lg:text-xl lg:leading-9">
+              <div className="scrollable-content max-h-[45vh] overflow-y-auto overscroll-contain pr-2 text-lg leading-7 text-white lg:text-xl lg:leading-9">
                 {ABOUT_BIO_LONG.map((paragraph, index) => (
                   <p key={index} className="mb-4">
                     {paragraph}

--- a/constants/SITE_CONTENT.ts
+++ b/constants/SITE_CONTENT.ts
@@ -32,10 +32,12 @@ export const INTRO_BIO_SHORT =
 
 export const ABOUT_BIO_LONG: string[] = [
   "I’m Dr. Derek Austin: an AI-Native Senior Full-Stack SWE, Fractional Architect, and Design Engineer. I specialize in architecting and building full-stack TypeScript apps that scale and world-class UI/UX that “feels” right.",
-  "I leverage frontier LLMs like Gemini Deep Think and Claude Opus every day, but I explicitly reject the technical debt of “vibe coding.” When using agentic and other AI-assisted SWE tools, I still take full ownership of the codebase and accountability for results.",
+  "I leverage frontier LLMs like Gemini Deep Think and Claude Opus every day, but I explicitly reject the technical debt of “vibe coding.”",
+  "When using agentic and other AI-assisted SWE tools, I still take full ownership of the codebase and accountability for results.",
   "Using my strict 5-Step Forge (Plan, Build, Test, Reflect) and 35 “Anti-Slop” pillars, I build with deterministic state machines (XState) and scrub AI slop from my codebases.",
   "This methodology drives my 10× development velocity across disparate stacks: Next.js, TypeScript, Node.js, and Postgres for cloud-native SaaS; React Native + Expo for cross-platform mobile apps; and Godot 4 + C# for indie games.",
-  "I’m a US citizen and operate as an independent US 1099 contractor as a digital nomad. Currently I’m based in Puebla, Mexico, where I live with my wife, Abby, and our two cats. Contact me for fractional architecture and engineering if results, accountability, and UI/UX matter to you!",
+  "I’m a US citizen and operate as an independent US 1099 contractor as a digital nomad. Currently, I’m based in Puebla, Mexico, where I live with my wife, Abby, and our two cats.",
+  "Contact me for fractional architecture and engineering if results, accountability, and UI/UX matter to you!",
 ] as const
 
 export type AiConsultancyPitch = {
@@ -47,7 +49,7 @@ export type AiConsultancyPitch = {
 }
 
 export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
-  header: "Fractional Architecture & Engineering",
+  header: "What I Do Best",
   body: "Startups are drowning in fragile, AI-generated prototypes that cannot scale. I help founders and VC-backed teams build deterministic apps in regulated industries (like HealthTech) at 10x velocity. I hate bugs, I love results, and I know when to move fast and when to pay down tech debt. I partner with teams as a Fractional Architect (part-time) or Design Engineer (full-time) to ship robust, world-class software that feels “right” for users.",
   ctaButtonText: "Inquire About Availability",
   subtext:
@@ -58,10 +60,9 @@ export const AI_CONSULTANCY_PITCH: AiConsultancyPitch = {
 export const CONTACT_BULLETS: string[] = [
   "I architect, build, and scale deterministic software systems using elite, AI-augmented engineering approaches including agentic SWE workflows.",
   "I’ve built my career around taking broken MVPs—whether delivered by underperforming agencies or AI—and turning them into real apps.",
-  "Currently, I partner with founders and early-stage startups on a fractional or full-time contract basis (US 1099 / Global B2B) to deliver 10x velocity without the technical debt of “vibe coding.”",
-  "Reach out to discuss how my 5-Step Forge (Plan, Build, Test, Reflect), Anti-Slop pillars, and commitment to using state machines for deterministic state management can accelerate your engineering pipeline.",
+  "I partner with founders and early-stage startups on a fractional or full-time contract basis (US 1099 / Global B2B) to deliver 10x velocity without the technical debt of “vibe coding.”",
 ] as const
-export const CONTACT_CTA = "Discuss Contract Engagement" as const
+export const CONTACT_CTA = "Contact Me" as const
 
 export type WorkExperience = {
   duration: string


### PR DESCRIPTION
## Summary

Implements 3 follow-up issues from #26 in a single PR.

closes #28, closes #29, closes #30

---

## Files Changed

| File | Change |
|---|---|
| `constants/SITE_CONTENT.ts` | Contact bullets/CTA, consultancy header, about bio splits + grammar |
| `components/AboutSection.tsx` | Layout overflow fix (3 levers) |

---

## Issue #28: Contact Section
- Removed `Currently, ` from bullet 3
- Deleted bullet 4 (methodology pitch) — 4 bullets → 3
- Changed `CONTACT_CTA` from `"Discuss Contract Engagement"` to `"Contact Me"`

## Issue #29: Consultancy Section
- Changed `AI_CONSULTANCY_PITCH.header` from `"Fractional Architecture & Engineering"` to `"What I Do Best"`
- Selected via Red Team analysis over 5 alternatives

## Issue #30: About Section

### Layout (AboutSection.tsx)
1. **Inner scrollbar**: Added `scrollable-content max-h-[45vh] overflow-y-auto overscroll-contain` to text div (compatible with fullpage.js `normalScrollElements`)
2. **Widened text container**: `md:w-[55%]` → `md:w-[65%]`, `lg:w-1/2` → `lg:w-[60%]`
3. **Widened outer wrapper**: `lg:w-3/4` → `lg:w-[90%]`

### Grammar (SITE_CONTENT.ts)
- `"Currently I’m based"` → `"Currently, I’m based"` (introductory adverb comma)

### Readability (SITE_CONTENT.ts)
- Split `ABOUT_BIO_LONG` from 5 strings to 7 strings for more `<p>` tags with equal spacing:
  - String 2 split: LLM stance | accountability (separate concepts)
  - String 5 split: personal info + location | CTA

---

## Typography Verification
All curly apostrophes (U+2019), curly quotes (U+201C/U+201D), em dashes (U+2014), and multiplication signs (U+00D7) verified correct via automated Unicode scanner.

---

## 5RUN QA Checklist
- [ ] **Contact**: 3 bullets render (no "Currently," prefix on bullet 3, no bullet 4)
- [ ] **Contact**: CTA button reads "Contact Me"
- [ ] **Consultancy**: Header reads "What I Do Best"
- [ ] **About**: Text box is wider and scrollable on desktop
- [ ] **About**: 7 paragraphs render with equal spacing
- [ ] **About**: "Currently, I’m based" has comma
- [ ] **About**: No text clipping on any viewport size
- [ ] No regressions in other sections