### PR TITLE
fix: contact section vertical centering (closes #32)

### DIFF
--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -10,7 +10,7 @@ export default function ContactSection() {
   const [isFlipped, setIsFlipped] = useState(false)
 
   return (
-    <div className="h-full w-full py-10 md:py-20">
+    <div className="flex h-full w-full items-center py-10 md:py-20">
       <div className="flex flex-col md:flex-row md:items-stretch">
         <div className="mx-auto w-[85%] md:flex md:w-1/2 md:flex-col md:pl-8 lg:w-[45%] lg:justify-start lg:pl-20">
           <div className="-translate-x-12 py-2 opacity-0 transition-all duration-700 ease-spring-soft md:mt-16 md:mb-2 lg:mb-0 lg:py-0 [.active_&]:translate-x-0 [.active_&]:opacity-100">
@@ -63,7 +63,7 @@ export default function ContactSection() {
         </div>
 
         <div className="mx-auto mt-4 flex w-full translate-y-12 flex-col opacity-0 transition-all delay-300 duration-700 ease-spring-soft md:mt-0 md:w-1/2 md:pl-8 lg:w-[55%] [.active_&]:translate-y-0 [.active_&]:opacity-100">
-          <div className="mx-auto mt-4 w-[90%] md:mt-32 md:ml-0 md:h-1/6 md:w-11/12 lg:my-auto lg:mr-0 lg:ml-auto lg:w-11/12 lg:pt-16 lg:pl-14">
+          <div className="mx-auto mt-4 w-[90%] md:ml-0 md:w-11/12 lg:mr-0 lg:ml-auto lg:w-11/12 lg:pl-14">
             <div className="space-y-4 rounded-xl border border-white/10 bg-black/40 px-5 py-6 text-lg leading-7 text-white shadow-xl backdrop-blur-md md:px-8 md:text-xl lg:pr-12 lg:text-2xl lg:leading-9">
               {CONTACT_BULLETS.map((bullet) => (
                 <p key={bullet} className="flex">


### PR DESCRIPTION
## Summary

Fixes Contact section content being vertically "pinned to the bottom" after bullet reduction in PR #31.

closes #32

---

## Root Cause

The Contact section used `items-stretch` columns + fixed `md:mt-32` margin instead of intrinsic vertical centering. Other sections (Blog, Consultancy, Testimonials, WorkExperience) all use `flex items-center justify-center` on the viewport wrapper.

With fewer bullets (3 vs 4), the fixed margin pushed content down with a large empty gap above.

## Fix

| Line | Before | After |
|---|---|---|
| 13 (outer wrapper) | `h-full w-full py-10 md:py-20` | `flex h-full w-full items-center py-10 md:py-20` |
| 66 (inner content) | `md:mt-32 md:h-1/6 lg:my-auto lg:pt-16` | *(removed)* |

## Full Section Audit

All 9 sections audited for vertical centering consistency:
- 7/9 use `flex items-center justify-center` (correct)
- 2/9 are intentional exceptions (IntroSection: top/bottom split, AboutSection: asymmetric photo overlay)
- No other sections need changes

## Files
- `components/ContactSection.tsx`

---

## 5RUN QA Checklist
- [ ] Contact section content is vertically centered in viewport
- [ ] Contact section looks correct on mobile, md, and lg breakpoints
- [ ] Left column (heading + image) and right column (bullets + CTA) are visually balanced
- [ ] No regressions in other sections