### PR TITLE
style: format repo with Prettier (yarn run format)

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -41,7 +41,7 @@ export default function AboutSection() {
       <div className="mx-auto w-4/5 md:w-[90%] lg:w-[90%]">
         <div className="-translate-x-12 py-2 text-white opacity-0 drop-shadow-md transition-all duration-700 ease-spring-soft md:relative md:pt-2 md:pb-8 lg:pt-3 lg:pb-10 [.active_&]:translate-x-0 [.active_&]:opacity-100">
           <SectionHeading>
-            <h2 className="text-5xl min-[375px]:text-6xl font-semibold md:text-8xl lg:text-9xl">
+            <h2 className="text-5xl font-semibold min-[375px]:text-6xl md:text-8xl lg:text-9xl">
               About
             </h2>
           </SectionHeading>
@@ -122,8 +122,8 @@ export default function AboutSection() {
               {SHOW_DR_MAPACHE && (
                 <div className="rounded-2xl border border-[#F38B57]/20 bg-black/50 p-4 shadow-xl backdrop-blur-md">
                   <p className="animate-pulse text-lg leading-tight font-bold text-white drop-shadow-md lg:text-xl">
-                    But enough talk. Scroll down to play the WebGL game I built to
-                    prove my stack. \ud83d\udc47\ud83c\udfae\ud83e\udd9d
+                    But enough talk. Scroll down to play the WebGL game I built
+                    to prove my stack. \ud83d\udc47\ud83c\udfae\ud83e\udd9d
                   </p>
                 </div>
               )}

--- a/components/AiConsultancySection.tsx
+++ b/components/AiConsultancySection.tsx
@@ -7,7 +7,7 @@ export default function AiConsultancySection() {
     <div className="flex h-full w-full items-center justify-center p-4 py-20 md:p-8">
       <div className="flex max-w-4xl translate-y-12 scale-95 flex-col rounded-2xl border border-white/20 bg-white/10 p-6 text-white opacity-0 backdrop-blur-md transition-all duration-700 ease-spring-bouncy md:p-12 [.active_&]:translate-y-0 [.active_&]:scale-100 [.active_&]:opacity-100">
         <SectionHeading className="mb-8">
-          <h2 className="text-balance text-4xl min-[375px]:text-5xl font-bold md:text-6xl">
+          <h2 className="text-4xl font-bold text-balance min-[375px]:text-5xl md:text-6xl">
             {AI_CONSULTANCY_PITCH.header}
           </h2>
         </SectionHeading>

--- a/components/BlogSection.tsx
+++ b/components/BlogSection.tsx
@@ -10,7 +10,7 @@ export default function BlogSection({ posts }: { posts: MediumPost[] }) {
     <>
       <div className="pointer-events-none absolute top-10 left-10 z-10 md:top-20 md:left-20">
         <SectionHeading>
-          <h2 className="text-5xl text-white drop-shadow-md md:text-8xl lg:text-9xl opacity-0 transition-all duration-700 ease-spring-soft [.active_&]:opacity-100">
+          <h2 className="text-5xl text-white opacity-0 drop-shadow-md transition-all duration-700 ease-spring-soft md:text-8xl lg:text-9xl [.active_&]:opacity-100">
             Blog
           </h2>
         </SectionHeading>
@@ -19,35 +19,61 @@ export default function BlogSection({ posts }: { posts: MediumPost[] }) {
       {/* Slide 1: Metrics */}
       <div className="slide">
         <div className="flex h-full w-full items-center justify-center p-4">
-          <div className="mx-auto mt-16 w-full max-w-4xl rounded-2xl border border-white/10 bg-black/40 p-6 text-white shadow-2xl backdrop-blur-md md:mt-24 md:p-12 opacity-0 transition-all duration-700 ease-spring-soft [.active_&]:opacity-100 translate-y-12 [.active_&]:translate-y-0">
+          <div className="mx-auto mt-16 w-full max-w-4xl translate-y-12 rounded-2xl border border-white/10 bg-black/40 p-6 text-white opacity-0 shadow-2xl backdrop-blur-md transition-all duration-700 ease-spring-soft md:mt-24 md:p-12 [.active_&]:translate-y-0 [.active_&]:opacity-100">
             <div className="mb-8 grid grid-cols-3 gap-2 md:gap-4">
               <div className="flex flex-col items-center justify-center text-center">
-                <p className="text-3xl font-bold md:text-5xl tabular-nums">
+                <p className="text-3xl font-bold tabular-nums md:text-5xl">
                   <CountUp to={BLOG_METRICS.totalPosts} />
                 </p>
-                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">Posts</p>
+                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">
+                  Posts
+                </p>
               </div>
               <div className="flex flex-col items-center justify-center border-x border-white/10 px-2 text-center">
-                <p className="text-3xl font-bold whitespace-nowrap md:text-5xl tabular-nums">
-                  <CountUp to={BLOG_METRICS.totalWordsK} duration={2.5} />k+
+                <p className="text-3xl font-bold whitespace-nowrap tabular-nums md:text-5xl">
+                  <CountUp to={BLOG_METRICS.totalWordsK} duration={2.5} />
+                  k+
                 </p>
-                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">Words</p>
+                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">
+                  Words
+                </p>
               </div>
               <div className="flex flex-col items-center justify-center text-center">
                 <p className="text-3xl font-bold md:text-5xl">
                   {BLOG_METRICS.yearStarted}
                 </p>
-                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">Since</p>
+                <p className="mt-1 text-[10px] font-bold tracking-wider text-white/80 uppercase md:text-sm">
+                  Since
+                </p>
               </div>
             </div>
             <h3 className="mb-8 text-center text-lg leading-snug font-bold text-white/90 md:text-2xl">
-              Tired of generic tech industry noise? Join <span className="text-[#F38B57] tabular-nums"><CountUp to={BLOG_METRICS.emailSubscribers} /></span> insider subscribers and <span className="text-[#008EC1] tabular-nums"><CountUp to={BLOG_METRICS.mediumFollowers} duration={2.5} /></span> followers reading my battle-tested systems analyses and survival manuals for your SWE career.
+              Tired of generic tech industry noise? Join{" "}
+              <span className="text-[#F38B57] tabular-nums">
+                <CountUp to={BLOG_METRICS.emailSubscribers} />
+              </span>{" "}
+              insider subscribers and{" "}
+              <span className="text-[#008EC1] tabular-nums">
+                <CountUp to={BLOG_METRICS.mediumFollowers} duration={2.5} />
+              </span>{" "}
+              followers reading my battle-tested systems analyses and survival
+              manuals for your SWE career.
             </h3>
             <div className="flex flex-col justify-center gap-4 md:flex-row">
-              <a href="https://doctorderek.medium.com/about" target="_blank" rel="noopener noreferrer" className="flex items-center justify-center rounded-xl bg-black/60 p-4 text-center text-sm font-bold text-white shadow-lg backdrop-blur-md transition-transform hover:scale-[1.02] active:scale-95 md:text-lg">
+              <a
+                href="https://doctorderek.medium.com/about"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center rounded-xl bg-black/60 p-4 text-center text-sm font-bold text-white shadow-lg backdrop-blur-md transition-transform hover:scale-[1.02] active:scale-95 md:text-lg"
+              >
                 Subscribe on Medium
               </a>
-              <a href="https://doctorderek.medium.com/" target="_blank" rel="noopener noreferrer" className="flex items-center justify-center rounded-xl border border-white/30 bg-white/20 p-4 text-center text-sm font-medium text-white backdrop-blur-md transition-transform hover:scale-105 hover:bg-white/30 active:scale-95 md:text-lg">
+              <a
+                href="https://doctorderek.medium.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center rounded-xl border border-white/30 bg-white/20 p-4 text-center text-sm font-medium text-white backdrop-blur-md transition-transform hover:scale-105 hover:bg-white/30 active:scale-95 md:text-lg"
+              >
                 Read All Posts
               </a>
             </div>
@@ -59,18 +85,39 @@ export default function BlogSection({ posts }: { posts: MediumPost[] }) {
       {posts.map((post) => (
         <div className="slide" key={post.link}>
           <div className="flex h-full w-full items-center justify-center p-4">
-            <a href={post.link} target="_blank" rel="noopener noreferrer" className="group mx-auto flex h-[65vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/20 bg-black/40 shadow-2xl backdrop-blur-md transition-transform duration-300 ease-spring-bouncy hover:-translate-y-2 hover:scale-[1.02] opacity-0 [.active_&]:opacity-100 scale-95 [.active_&]:scale-100">
+            <a
+              href={post.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group mx-auto flex h-[65vh] w-full max-w-2xl scale-95 flex-col overflow-hidden rounded-2xl border border-white/20 bg-black/40 opacity-0 shadow-2xl backdrop-blur-md transition-transform duration-300 ease-spring-bouncy hover:-translate-y-2 hover:scale-[1.02] [.active_&]:scale-100 [.active_&]:opacity-100"
+            >
               <div className="relative h-1/2 w-full shrink-0 border-b border-white/20 bg-[#1E1E1E]">
-                <p className="absolute top-3 left-4 z-10 rounded-tr-xl border border-white/20 bg-black/60 px-3 py-1 text-xs font-bold text-white backdrop-blur-md">Medium</p>
+                <p className="absolute top-3 left-4 z-10 rounded-tr-xl border border-white/20 bg-black/60 px-3 py-1 text-xs font-bold text-white backdrop-blur-md">
+                  Medium
+                </p>
                 {post.thumbnail && (
-                  <Image src={post.thumbnail} alt={post.title} fill sizes="(max-width: 768px) 100vw, 50vw" className="object-cover opacity-90 transition-opacity duration-500 group-hover:scale-105 group-hover:opacity-100" />
+                  <Image
+                    src={post.thumbnail}
+                    alt={post.title}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                    className="object-cover opacity-90 transition-opacity duration-500 group-hover:scale-105 group-hover:opacity-100"
+                  />
                 )}
               </div>
               <div className="flex flex-1 flex-col p-6 lg:p-8">
-                <h4 className="mb-3 line-clamp-3 text-xl leading-tight font-bold text-white md:text-2xl lg:text-3xl">{post.title}</h4>
-                <p className="mb-auto line-clamp-4 text-sm text-white/80 md:text-base lg:text-lg">{post.description}</p>
+                <h4 className="mb-3 line-clamp-3 text-xl leading-tight font-bold text-white md:text-2xl lg:text-3xl">
+                  {post.title}
+                </h4>
+                <p className="mb-auto line-clamp-4 text-sm text-white/80 md:text-base lg:text-lg">
+                  {post.description}
+                </p>
                 <p className="mt-4 text-xs font-bold tracking-wider text-white uppercase opacity-70 lg:text-sm">
-                  {new Date(post.pubDate).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+                  {new Date(post.pubDate).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
                 </p>
               </div>
             </a>

--- a/components/ContactSection.tsx
+++ b/components/ContactSection.tsx
@@ -21,7 +21,7 @@ export default function ContactSection() {
             </SectionHeading>
           </div>
 
-          <div className="w-1/2 mx-auto md:mx-0 translate-y-12 scale-90 opacity-0 transition-all delay-200 duration-700 ease-spring-bouncy md:h-1/2 md:w-full [.active_&]:translate-y-0 [.active_&]:scale-100 [.active_&]:opacity-100">
+          <div className="mx-auto w-1/2 translate-y-12 scale-90 opacity-0 transition-all delay-200 duration-700 ease-spring-bouncy md:mx-0 md:h-1/2 md:w-full [.active_&]:translate-y-0 [.active_&]:scale-100 [.active_&]:opacity-100">
             <div
               className="perspective h-full w-full animate-float"
               style={{ animationDelay: "1s" }}

--- a/components/DrMapacheSection.tsx
+++ b/components/DrMapacheSection.tsx
@@ -14,9 +14,7 @@ export default function DrMapacheSection() {
           <p className="animate-pulse text-2xl font-bold text-white">
             [ WebGL Game Canvas Placeholder ]
           </p>
-          <p className="mt-8 text-xl text-white/60">
-            (Inputs isolated)
-          </p>
+          <p className="mt-8 text-xl text-white/60">(Inputs isolated)</p>
         </div>
       </div>
     </div>

--- a/components/Portfolio.tsx
+++ b/components/Portfolio.tsx
@@ -48,7 +48,15 @@ const projects = [
 ]
 
 export default function Portfolio() {
-  const [portfolioWork, setPortfolioWork] = useState<{ projectTitle: string, details: string, tech: string[], isClicked: boolean }[]>(projects)
+  const [portfolioWork, setPortfolioWork] =
+    useState<
+      {
+        projectTitle: string
+        details: string
+        tech: string[]
+        isClicked: boolean
+      }[]
+    >(projects)
   const [showModal, setShowModal] = useState<boolean>(false)
 
   const handleModal = (projectName: string) => {
@@ -73,7 +81,7 @@ export default function Portfolio() {
           <div className="flex h-full w-full items-center justify-center p-8">
             <div
               onClick={() => handleModal(item.projectTitle)}
-              className="flex h-full max-h-[60vh] w-full max-w-4xl cursor-pointer flex-col justify-around rounded-3xl border border-white/20 bg-white/10 p-8 text-white backdrop-blur-md transition-all duration-300 ease-spring-bouncy hover:scale-[1.02] hover:bg-white/20 md:p-16 opacity-0 [.active_&]:opacity-100 scale-95 [.active_&]:scale-100"
+              className="flex h-full max-h-[60vh] w-full max-w-4xl scale-95 cursor-pointer flex-col justify-around rounded-3xl border border-white/20 bg-white/10 p-8 text-white opacity-0 backdrop-blur-md transition-all duration-300 ease-spring-bouncy hover:scale-[1.02] hover:bg-white/20 md:p-16 [.active_&]:scale-100 [.active_&]:opacity-100"
             >
               <div className="mx-auto mb-8 h-[25vh] w-full rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md"></div>
               <h3 className="restorabold mb-4 text-3xl lg:text-5xl">

--- a/components/PostsSection.tsx
+++ b/components/PostsSection.tsx
@@ -12,7 +12,7 @@ export default function PostsSection({ posts }: { posts: MediumPost[] }) {
               href={post.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="group mx-auto flex h-[65vh] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/20 bg-black/40 shadow-2xl backdrop-blur-md transition-transform duration-300 ease-spring-bouncy hover:-translate-y-2 hover:scale-[1.02] opacity-0 [.active_&]:opacity-100 scale-95 [.active_&]:scale-100"
+              className="group mx-auto flex h-[65vh] w-full max-w-2xl scale-95 flex-col overflow-hidden rounded-2xl border border-white/20 bg-black/40 opacity-0 shadow-2xl backdrop-blur-md transition-transform duration-300 ease-spring-bouncy hover:-translate-y-2 hover:scale-[1.02] [.active_&]:scale-100 [.active_&]:opacity-100"
             >
               <div className="relative h-1/2 w-full shrink-0 border-b border-white/20 bg-[#1E1E1E]">
                 <p className="absolute top-3 left-4 z-10 rounded-tr-xl border border-white/20 bg-black/60 px-3 py-1 text-xs font-bold text-white backdrop-blur-md">

--- a/components/Testimonials.tsx
+++ b/components/Testimonials.tsx
@@ -20,7 +20,7 @@ const Testimonials = () => {
       {TESTIMONIALS.map((item: Testimonial) => (
         <div key={item.name} className="slide">
           <div className="flex h-full w-full items-center justify-center p-4 py-20 md:p-8">
-            <div className="mx-auto mt-16 w-full max-w-4xl rounded-2xl border border-white/10 bg-black/40 p-6 text-white shadow-2xl backdrop-blur-md transition-all duration-700 ease-spring-soft scale-95 opacity-0 [.active_&]:scale-100 [.active_&]:opacity-100 md:mt-24 md:p-12">
+            <div className="mx-auto mt-16 w-full max-w-4xl scale-95 rounded-2xl border border-white/10 bg-black/40 p-6 text-white opacity-0 shadow-2xl backdrop-blur-md transition-all duration-700 ease-spring-soft md:mt-24 md:p-12 [.active_&]:scale-100 [.active_&]:opacity-100">
               <div className="mb-8 flex items-center">
                 <div className="mr-6 shrink-0">
                   <Image
@@ -34,10 +34,12 @@ const Testimonials = () => {
                 </div>
                 <div className="flex flex-col">
                   <h4 className="text-lg font-bold md:text-2xl">{item.name}</h4>
-                  <h4 className="text-sm opacity-80 md:text-base">{item.title}</h4>
+                  <h4 className="text-sm opacity-80 md:text-base">
+                    {item.title}
+                  </h4>
                 </div>
               </div>
-              <div className="scrollable-content space-y-4 text-sm leading-relaxed max-h-[40vh] overflow-y-auto overscroll-contain pr-2 md:text-lg md:leading-8 lg:text-xl lg:leading-9">
+              <div className="scrollable-content max-h-[40vh] space-y-4 overflow-y-auto overscroll-contain pr-2 text-sm leading-relaxed md:text-lg md:leading-8 lg:text-xl lg:leading-9">
                 {item.comment.split("\n\n").map((paragraph, i) => (
                   <p key={i}>{paragraph}</p>
                 ))}

--- a/components/TopSection.tsx
+++ b/components/TopSection.tsx
@@ -18,7 +18,7 @@ const TypewriterOnInit = (typewriter: TypewriterClass) => {
 
 export default function TopSection() {
   return (
-    <div className="absolute inset-0 flex flex-col w-full h-full">
+    <div className="absolute inset-0 flex h-full w-full flex-col">
       <Navbar />
       {/* flex-1 offsets the Navbar to prevent double scrolling */}
       <div className="flex flex-1 translate-y-12 scale-95 flex-col items-center justify-center opacity-0 transition-all duration-700 ease-spring-bouncy [.active_&]:translate-y-0 [.active_&]:scale-100 [.active_&]:opacity-100">

--- a/components/WorkExperienceSection.tsx
+++ b/components/WorkExperienceSection.tsx
@@ -18,11 +18,12 @@ export default function WorkExperienceSection() {
 
   return (
     <div className="relative flex h-full w-full flex-col items-center justify-center py-20 pb-24">
-      <div className="translate-x-12 rounded-bl-[3rem] bg-black/60 px-6 py-6 opacity-0 backdrop-blur-md transition-all duration-700 ease-spring-soft lg:ml-auto lg:w-fit lg:pb-8 lg:pl-16 lg:pr-8 [.active_&]:translate-x-0 [.active_&]:opacity-100">
+      <div className="translate-x-12 rounded-bl-[3rem] bg-black/60 px-6 py-6 opacity-0 backdrop-blur-md transition-all duration-700 ease-spring-soft lg:ml-auto lg:w-fit lg:pr-8 lg:pb-8 lg:pl-16 [.active_&]:translate-x-0 [.active_&]:opacity-100">
         <div className="flex flex-col items-end">
           <SectionHeading>
-            <h2 className="min-[375px]:text-3xl text-right text-3xl font-bold tracking-tight text-white drop-shadow-md whitespace-nowrap sm:text-4xl md:text-5xl lg:text-7xl">
-              Full-Stack SWE<br />
+            <h2 className="text-right text-3xl font-bold tracking-tight whitespace-nowrap text-white drop-shadow-md min-[375px]:text-3xl sm:text-4xl md:text-5xl lg:text-7xl">
+              Full-Stack SWE
+              <br />
               since 2005
             </h2>
           </SectionHeading>
@@ -30,7 +31,7 @@ export default function WorkExperienceSection() {
       </div>
 
       <div className="mx-auto mt-6 w-[95%] translate-y-12 opacity-0 transition-all delay-200 duration-700 ease-spring-soft lg:hidden [.active_&]:translate-y-0 [.active_&]:opacity-100">
-        <ul className="mt-2 flex flex-col gap-y-6 pr-2 pl-4 pb-8">
+        <ul className="mt-2 flex flex-col gap-y-6 pr-2 pb-8 pl-4">
           {ARCHITECT_EVOLUTION.map((item, index) => (
             <li
               key={item.company}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -28,12 +28,7 @@ export default function Icon({
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d={PATHS[name]}
-        fill={fill}
-      />
+      <path fillRule="evenodd" clipRule="evenodd" d={PATHS[name]} fill={fill} />
     </svg>
   )
 }

--- a/components/ui/SectionHeading.tsx
+++ b/components/ui/SectionHeading.tsx
@@ -7,7 +7,10 @@ type SectionHeadingProps = {
   className?: string
 }
 
-export default function SectionHeading({ children, className }: SectionHeadingProps) {
+export default function SectionHeading({
+  children,
+  className,
+}: SectionHeadingProps) {
   return (
     <Tilt
       className={classNames("w-max cursor-pointer", className)}

--- a/components/ui/SocialLinks.tsx
+++ b/components/ui/SocialLinks.tsx
@@ -41,9 +41,12 @@ export default function SocialLinks({
 
         if (isEmail) {
           return (
-            <GlobalEmailCTA 
-              key={link.id} 
-              className={classNames(linkClasses, "[&_a]:flex [&_a]:items-center")}
+            <GlobalEmailCTA
+              key={link.id}
+              className={classNames(
+                linkClasses,
+                "[&_a]:flex [&_a]:items-center",
+              )}
             >
               {content}
             </GlobalEmailCTA>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -58,9 +58,18 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
     { component: <TopSection key="top" />, anchor: "home" },
     { component: <IntroSection key="intro" />, anchor: "intro" },
     { component: <AboutSection key="about" />, anchor: "about" },
-    SHOW_DR_MAPACHE && { component: <DrMapacheSection key="mapache" />, anchor: "mapache" },
-    { component: <WorkExperienceSection key="experience" />, anchor: "experience" },
-    { component: <AiConsultancySection key="consultancy" />, anchor: "consultancy" },
+    SHOW_DR_MAPACHE && {
+      component: <DrMapacheSection key="mapache" />,
+      anchor: "mapache",
+    },
+    {
+      component: <WorkExperienceSection key="experience" />,
+      anchor: "experience",
+    },
+    {
+      component: <AiConsultancySection key="consultancy" />,
+      anchor: "consultancy",
+    },
     { component: <Testimonials key="testimonials" />, anchor: "testimonials" },
     { component: <BlogSection key="blog" posts={posts} />, anchor: "blog" },
     { component: <ContactSection key="contact" />, anchor: "contact" },
@@ -69,18 +78,18 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
 
   const handleLeave = (origin: any, destination: any, direction: string) => {
     const transitionMatrix: Record<string, string> = {
-      "home": "zoom",
-      "intro": "zoom",
-      "about": "chromatic",
-      "mapache": "pixelate",
-      "experience": SHOW_DR_MAPACHE ? "shatter" : "pixelate",
-      "consultancy": "shockwave",
-      "testimonials": "doorway",
-      "blog": "pageCurlLeft",
-      "contact": "burn",
-      "footer": "fade",
+      home: "zoom",
+      intro: "zoom",
+      about: "chromatic",
+      mapache: "pixelate",
+      experience: SHOW_DR_MAPACHE ? "shatter" : "pixelate",
+      consultancy: "shockwave",
+      testimonials: "doorway",
+      blog: "pageCurlLeft",
+      contact: "burn",
+      footer: "fade",
     }
-    
+
     const nextEffect = transitionMatrix[destination.anchor] || "fade"
     setCinematicEffect(nextEffect)
   }
@@ -89,7 +98,8 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
     <>
       <Head>
         <title>
-          Dr. Derek Austin | Indie Game Dev, AI Context Engineer, Full-Stack SWE, & Content Creator
+          Dr. Derek Austin | Indie Game Dev, AI Context Engineer, Full-Stack
+          SWE, & Content Creator
         </title>
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
       </Head>
@@ -98,7 +108,6 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
       <MapacheFullPage
         pluginWrapper={pluginWrapper}
         licenseKey={FULLPAGE_JS_LICENSE_FOR_REACT_FULLPAGE_JS}
-        
         cardsKey={FULLPAGE_ACTIVATION_KEYS.cards}
         cinematicKey={FULLPAGE_ACTIVATION_KEYS.cinematic}
         continuousHorizontalKey={FULLPAGE_ACTIVATION_KEYS.continuousHorizontal}
@@ -108,7 +117,6 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
         responsiveSlidesKey={FULLPAGE_ACTIVATION_KEYS.responsiveSlides}
         scrollHorizontallyKey={FULLPAGE_ACTIVATION_KEYS.scrollHorizontally}
         scrollOverflowResetKey={FULLPAGE_ACTIVATION_KEYS.scrollOverflowReset}
-
         dragAndMove={true}
         scrollHorizontally={false}
         offsetSections={true}
@@ -120,28 +128,26 @@ export default function Home({ posts }: { posts: MediumPost[] }) {
         resetSliders={true}
         cards="slides"
         cinematic={true}
-
         cinematicOptions={{ effect: cinematicEffect }}
         credits={{ enabled: false }}
         anchors={sectionsContent.map((s) => s.anchor)}
         onLeave={handleLeave}
-        
         render={() => (
           <ReactFullpage.Wrapper>
             {sectionsContent.map((section, index) => (
-              <div 
-                key={section.anchor} 
+              <div
+                key={section.anchor}
                 className={classNames(
                   "section",
                   section.anchor === "footer" ? "fp-auto-height" : "",
-                  section.anchor === "home" ? "fp-noscroll" : ""
+                  section.anchor === "home" ? "fp-noscroll" : "",
                 )}
               >
                 {section.component}
                 {index < sectionsContent.length - 1 && (
                   <a
                     href={`#${sectionsContent[index + 1].anchor}`}
-                    className="sr-only focus:not-sr-only focus:absolute focus:bottom-8 focus:right-8 focus:z-[9999] rounded-lg bg-black/60 px-6 py-3 font-semibold text-white outline-none ring-2 ring-yellow-400 backdrop-blur-md transition-all ease-spring-bouncy hover:scale-105"
+                    className="sr-only rounded-lg bg-black/60 px-6 py-3 font-semibold text-white ring-2 ring-yellow-400 backdrop-blur-md transition-all ease-spring-bouncy outline-none hover:scale-105 focus:not-sr-only focus:absolute focus:right-8 focus:bottom-8 focus:z-[9999]"
                   >
                     Skip to next section ↓
                   </a>

--- a/repomix.config.json5
+++ b/repomix.config.json5
@@ -41,10 +41,7 @@
   ignore: {
     useGitignore: true,
     useDefaultPatterns: true,
-    customPatterns: [
-      "public/**/*",
-      "reference/**/*",
-    ],
+    customPatterns: ["public/**/*", "reference/**/*"],
   },
   security: {
     enableSecurityCheck: true,

--- a/scripts/decrypt-assets.js
+++ b/scripts/decrypt-assets.js
@@ -10,15 +10,18 @@ const ASSET_KEY = process.env.GHOST_ASSET_KEY_DOCTORDEREK_COM
 const ARCHIVES = [
   {
     name: "FullPage Extensions",
-    zipPath: path.join(__dirname, "../ghost_assets/fullPage_js_extensions_bundle.zip"),
+    zipPath: path.join(
+      __dirname,
+      "../ghost_assets/fullPage_js_extensions_bundle.zip",
+    ),
     targetDir: path.join(__dirname, "../vendor"),
-    junkPaths: false // Keeps internal folder structure (e.g., /cinematic/)
+    junkPaths: false, // Keeps internal folder structure (e.g., /cinematic/)
   },
   {
     name: "Restora Fonts",
     zipPath: path.join(__dirname, "../ghost_assets/fonts.zip"),
     targetDir: path.join(__dirname, "../vendor/fonts"),
-    junkPaths: true // Flattens directory structure so .otf files land directly in vendor/fonts/
+    junkPaths: true, // Flattens directory structure so .otf files land directly in vendor/fonts/
   },
 ]
 
@@ -42,13 +45,16 @@ try {
         console.log(`📁 Creating directory: ${archive.targetDir}`)
         fs.mkdirSync(archive.targetDir, { recursive: true })
       }
-      
+
       console.log(`📦 Unzipping payload: ${archive.name}`)
       // -j flag ignores zip folder structure and puts files directly in targetDir
       const junkFlag = archive.junkPaths ? "-j " : ""
-      execSync(`unzip -o -q ${junkFlag}-P "${ASSET_KEY}" "${archive.zipPath}" -d "${archive.targetDir}"`, {
-        stdio: "inherit",
-      })
+      execSync(
+        `unzip -o -q ${junkFlag}-P "${ASSET_KEY}" "${archive.zipPath}" -d "${archive.targetDir}"`,
+        {
+          stdio: "inherit",
+        },
+      )
     } else {
       console.warn(`⚠️ Warning: Archive not found at ${archive.zipPath}`)
     }
@@ -57,10 +63,12 @@ try {
   console.log("✅ GHOST PIPELINE SUCCESS: Commercial assets injected.")
   console.log("[$̲̅(̲̅ιοο̲̅)̲̅$̲̅] Proceeding with Vercel build...")
   console.log("=========================================")
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
 } catch (error) {
   console.error("❌ FATAL ERROR: Decryption failed.")
-  console.error("Possible causes: Wrong GHOST_ASSET_KEY_DOCTORDEREK_COM or missing unzip utility.")
+  console.error(
+    "Possible causes: Wrong GHOST_ASSET_KEY_DOCTORDEREK_COM or missing unzip utility.",
+  )
   console.log("=========================================")
   process.exit(1)
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -125,7 +125,6 @@ button {
   font-family: "Restorabold";
 }
 
-
 /* =========================== 
   WORK EXPERIENCE SECTION 
 ============================== */

--- a/types/MapacheFullPageProps.ts
+++ b/types/MapacheFullPageProps.ts
@@ -128,12 +128,12 @@ export type MapacheFullPageProps = {
     section: any,
     origin: any,
     destination: any,
-    direction: string
+    direction: string,
   ) => void
   onSlideLeave?: (
     section: any,
     origin: any,
     destination: any,
-    direction: string
+    direction: string,
   ) => void
 }

--- a/utils/medium.ts
+++ b/utils/medium.ts
@@ -9,25 +9,29 @@ export interface MediumPost {
 }
 
 const decodeEntities = (str: string) => {
-  return str
-    // Decode hexadecimal numeric entities (e.g., &#x201C;)
-    .replace(/&#x([0-9A-Fa-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
-    // Decode decimal numeric entities (e.g., &#8220;)
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
-    // Decode common named entities
-    .replace(/&quot;/g, "”")
-    .replace(/&apos;/g, "’")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&rsquo;/g, "’")
-    .replace(/&lsquo;/g, "‘")
-    .replace(/&rdquo;/g, "”")
-    .replace(/&ldquo;/g, "“")
-    .replace(/&mdash;/g, "—")
-    .replace(/&ndash;/g, "–")
-    .replace(/&hellip;/g, "…")
-    .replace(/&nbsp;/g, " ")
+  return (
+    str
+      // Decode hexadecimal numeric entities (e.g., &#x201C;)
+      .replace(/&#x([0-9A-Fa-f]+);/gi, (_, hex) =>
+        String.fromCodePoint(parseInt(hex, 16)),
+      )
+      // Decode decimal numeric entities (e.g., &#8220;)
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)))
+      // Decode common named entities
+      .replace(/&quot;/g, "”")
+      .replace(/&apos;/g, "’")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&rsquo;/g, "’")
+      .replace(/&lsquo;/g, "‘")
+      .replace(/&rdquo;/g, "”")
+      .replace(/&ldquo;/g, "“")
+      .replace(/&mdash;/g, "—")
+      .replace(/&ndash;/g, "–")
+      .replace(/&hellip;/g, "…")
+      .replace(/&nbsp;/g, " ")
+  )
 }
 
 export default async function getMediumPosts(): Promise<MediumPost[]> {
@@ -39,18 +43,21 @@ export default async function getMediumPosts(): Promise<MediumPost[]> {
       item["content:encoded"] || item.content || item.description || ""
 
     // Find all images, select the first that isn't a tracking pixel
-    const imgMatches = Array.from(content.matchAll(/<img[^>]+src="([^">]+)"/g)) as RegExpMatchArray[]
+    const imgMatches = Array.from(
+      content.matchAll(/<img[^>]+src="([^">]+)"/g),
+    ) as RegExpMatchArray[]
     const validImage = imgMatches.find(
       (m) => !m[1].includes("stat?event") && !m[1].includes("stat.medium.com"),
     )
     const thumbnail = validImage ? validImage[1] : ""
 
-    const description = decodeEntities(
-      content
-        .replace(/<[^>]*>?/gm, "")
-        .replace(/&nbsp;/g, " ")
-        .trim()
-    ).substring(0, 180) + "..."
+    const description =
+      decodeEntities(
+        content
+          .replace(/<[^>]*>?/gm, "")
+          .replace(/&nbsp;/g, " ")
+          .trim(),
+      ).substring(0, 180) + "..."
 
     return {
       title: decodeEntities(item.title || ""),


### PR DESCRIPTION
Closes #39.

## Changes

Ran `yarn run format` (`prettier --write .`) applying Prettier formatting to 19 files. Pure formatting pass — zero logic changes.

### Files Changed

- `components/AboutSection.tsx`
- `components/AiConsultancySection.tsx`
- `components/BlogSection.tsx`
- `components/ContactSection.tsx`
- `components/DrMapacheSection.tsx`
- `components/Portfolio.tsx`
- `components/PostsSection.tsx`
- `components/Testimonials.tsx`
- `components/TopSection.tsx`
- `components/WorkExperienceSection.tsx`
- `components/ui/Icon.tsx`
- `components/ui/SectionHeading.tsx`
- `components/ui/SocialLinks.tsx`
- `pages/index.tsx`
- `repomix.config.json5`
- `scripts/decrypt-assets.js`
- `styles/globals.css`
- `types/MapacheFullPageProps.ts`
- `utils/medium.ts`

## 5RUN QA Checklist

- [ ] Verify diff contains only whitespace/formatting changes (no logic)
- [ ] Confirm `yarn run format` produces no further changes (idempotent)
- [ ] Optionally run `yarn build` to confirm no breakage