### PR TITLE
fix: correct 'since 2005' to 'since 2004' for accuracy

### DIFF
--- a/components/WorkExperienceSection.tsx
+++ b/components/WorkExperienceSection.tsx
@@ -24,7 +24,7 @@ export default function WorkExperienceSection() {
             <h2 className="text-right text-3xl font-bold tracking-tight whitespace-nowrap text-white drop-shadow-md min-[375px]:text-3xl sm:text-4xl md:text-5xl lg:text-7xl">
               Full-Stack SWE
               <br />
-              since 2005
+              since 2004
             </h2>
           </SectionHeading>
         </div>


### PR DESCRIPTION
Closes #38.

## Changes

Corrected "since 2005" to "since 2004" in `WorkExperienceSection.tsx` for factual accuracy. Follow-up to #16.

### Files Changed

- `components/WorkExperienceSection.tsx` (line 27: `since 2005` → `since 2004`)

## 5RUN QA Checklist

- [ ] Verify the Work Experience heading reads "since 2004" on the live site
- [ ] Confirm no other occurrences of "2005" remain in the codebase