### PR TITLE
feat: Antigravity-inspired mouse-reactive particle physics (Issue #6)

### DIFF
--- a/components/ParticleCanvas.tsx
+++ b/components/ParticleCanvas.tsx
@@ -1,46 +1,119 @@
 "use client"
 import { useEffect, useRef } from "react"
 
+const INFLUENCE_RADIUS = 150
+const REPULSION_STRENGTH = 8
+const DAMPING = 0.92
+const SPRING_BACK = 0.02
+const GLOW_RADIUS_MULTIPLIER = 1.5
+
+const MAPACHITO_VIVID_COLORS = [
+  "rgba(0, 139, 139, 0.6)",
+  "rgba(156, 0, 82, 0.6)",
+  "rgba(0, 142, 193, 0.6)",
+  "rgba(255, 69, 0, 0.6)",
+  "rgba(121, 15, 197, 0.6)",
+  "rgba(0, 143, 57, 0.6)",
+]
+
 class Particle {
   x: number
   y: number
+  homeX: number
+  homeY: number
+  vx: number
+  vy: number
   radius: number
+  baseRadius: number
   speedY: number
   speedX: number
   opacity: number
   wobble: number
+  color: string
 
   constructor(canvasWidth: number, canvasHeight: number) {
     this.x = Math.random() * canvasWidth
     this.y = Math.random() * canvasHeight
-    this.radius = Math.random() * 4 + 1
+    this.homeX = this.x
+    this.homeY = this.y
+    this.vx = 0
+    this.vy = 0
+    this.baseRadius = Math.random() * 4 + 1
+    this.radius = this.baseRadius
     this.speedY = Math.random() * -1 - 0.5
     this.speedX = Math.random() * 1 - 0.5
     this.opacity = Math.random() * 0.5 + 0.1
     this.wobble = Math.random() * Math.PI * 2
+
+    this.color =
+      Math.random() < 0.2
+        ? MAPACHITO_VIVID_COLORS[
+            Math.floor(Math.random() * MAPACHITO_VIVID_COLORS.length)
+          ]
+        : `rgba(255, 255, 255, ${this.opacity})`
   }
 
-  update(canvasWidth: number, canvasHeight: number) {
-    this.y += this.speedY
+  update(
+    canvasWidth: number,
+    canvasHeight: number,
+    mouseX: number | null,
+    mouseY: number | null,
+  ) {
     this.wobble += 0.02
-    this.x += Math.sin(this.wobble) * this.speedX
+    this.homeY += this.speedY
+    this.homeX += Math.sin(this.wobble) * this.speedX
 
-    if (this.y + this.radius < 0) {
-      this.y = canvasHeight + this.radius
-      this.x = Math.random() * canvasWidth
+    if (this.homeY + this.baseRadius < 0) {
+      this.homeY = canvasHeight + this.baseRadius
+      this.homeX = Math.random() * canvasWidth
     }
+
+    if (mouseX !== null && mouseY !== null) {
+      const dx = this.x - mouseX
+      const dy = this.y - mouseY
+      const distance = Math.sqrt(dx * dx + dy * dy)
+
+      if (distance < INFLUENCE_RADIUS && distance > 0) {
+        const normalizedDistance = 1 - distance / INFLUENCE_RADIUS
+        const force = normalizedDistance * normalizedDistance * REPULSION_STRENGTH
+        const angle = Math.atan2(dy, dx)
+        this.vx += Math.cos(angle) * force
+        this.vy += Math.sin(angle) * force
+        this.radius =
+          this.baseRadius +
+          (this.baseRadius * (GLOW_RADIUS_MULTIPLIER - 1) * normalizedDistance)
+      } else {
+        this.radius += (this.baseRadius - this.radius) * 0.1
+      }
+    } else {
+      this.radius += (this.baseRadius - this.radius) * 0.1
+    }
+
+    this.vx += (this.homeX - this.x) * SPRING_BACK
+    this.vy += (this.homeY - this.y) * SPRING_BACK
+
+    this.vx *= DAMPING
+    this.vy *= DAMPING
+
+    this.x += this.vx
+    this.y += this.vy
   }
 
   draw(ctx: CanvasRenderingContext2D) {
     ctx.beginPath()
     ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2)
-    ctx.fillStyle = `rgba(255, 255, 255, ${this.opacity})`
+    ctx.fillStyle = this.color
     ctx.fill()
     ctx.closePath()
   }
 }
+
 export default function ParticleCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const mouseRef = useRef<{ x: number | null; y: number | null }>({
+    x: null,
+    y: null,
+  })
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -65,13 +138,27 @@ export default function ParticleCanvas() {
       initParticles()
     }
 
+    const handleMouseMove = (e: MouseEvent) => {
+      mouseRef.current.x = e.clientX
+      mouseRef.current.y = e.clientY
+    }
+
+    const handleMouseLeave = () => {
+      mouseRef.current.x = null
+      mouseRef.current.y = null
+    }
+
     window.addEventListener("resize", resize)
+    window.addEventListener("mousemove", handleMouseMove, { passive: true })
+    document.addEventListener("mouseleave", handleMouseLeave)
+
     resize()
 
     const render = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height)
+      const { x: mouseX, y: mouseY } = mouseRef.current
       for (let i = 0; i < particles.length; i++) {
-        particles[i].update(canvas.width, canvas.height)
+        particles[i].update(canvas.width, canvas.height, mouseX, mouseY)
         particles[i].draw(ctx)
       }
       animationFrameId = requestAnimationFrame(render)
@@ -81,6 +168,8 @@ export default function ParticleCanvas() {
 
     return () => {
       window.removeEventListener("resize", resize)
+      window.removeEventListener("mousemove", handleMouseMove)
+      document.removeEventListener("mouseleave", handleMouseLeave)
       cancelAnimationFrame(animationFrameId)
     }
   }, [])


### PR DESCRIPTION
## Summary

Upgrades `ParticleCanvas.tsx` with Antigravity-inspired mouse-reactive particle physics. Particles scatter from the cursor via repulsion force vectors and spring back via damping. ~20% of particles use Mapachito Vivid brand colors.

Closes #6

## Files Changed

| File | Action | Detail |
|------|--------|--------|
| `components/ParticleCanvas.tsx` | MODIFY | +98/-9 — mouse repulsion physics, spring-back damping, glow scaling, brand color accents |

## Architecture

- **Zero new dependencies.** Pure Canvas 2D physics.
- **Mouse repulsion:** 150px influence radius, quadratic force falloff, `REPULSION_STRENGTH = 8`.
- **Spring-back:** Each particle stores a `homeX/homeY` anchor. Spring constant `0.02`, velocity damping `0.92`.
- **Glow:** Particles near cursor scale to 1.5× base radius.
- **Colors:** ~20% particles tinted with Mapachito Vivid Palette (Deep Cyan, Raspberry, Blue, Orange, Purple, Green).
- **Mobile:** No `touchmove` — effect gracefully absent on touch devices.
- **Preserved:** All existing ambient drift, wobble, opacity, z-index (`z-0`), `pointer-events-none`.

## 5RUN QA Checklist

- [ ] `yarn dev` — site loads without errors
- [ ] Particles render ambient floating (existing behavior preserved)
- [ ] Mouse movement causes particles to scatter away from cursor
- [ ] Particles smoothly spring back after cursor moves away
- [ ] ~20% particles show colored tints
- [ ] Effect absent on mobile/touch
- [ ] CustomCursor orange ring still renders on top (`z-[9999]`)
- [ ] Rive animation overlay still visible (`z-10`)
- [ ] No performance degradation
- [ ] No console errors